### PR TITLE
WIP - V1 - Make it practical

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 .tests
 .coverage
 documentation.json
+_documentation.json

--- a/madlib.json
+++ b/madlib.json
@@ -4,6 +4,10 @@
   "main": "src/Main.mad",
   "bin": "src/CLI/Main.mad",
   "dependencies": {
-    "MadUI": "https://github.com/madlib-lang/madui/archive/refs/heads/master.zip"
+    "MadUI": "https://github.com/madlib-lang/madui/archive/refs/heads/master.zip",
+    "MarkdownRenderer": "https://github.com/madlib-lang/madmarkdown-renderer/archive/refs/heads/master.zip"
+  },
+  "importAliases": {
+    "@": "src"
   }
 }

--- a/madlib.json
+++ b/madlib.json
@@ -1,13 +1,13 @@
 {
   "name": "MadDoc",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "main": "src/Main.mad",
-  "bin": "src/CLI/Main.mad",
+  "madlibVersion": "0.9.0",
   "dependencies": {
     "MadUI": "https://github.com/madlib-lang/madui/archive/refs/heads/master.zip",
     "MarkdownRenderer": "https://github.com/madlib-lang/madmarkdown-renderer/archive/refs/heads/master.zip"
   },
   "importAliases": {
-    "@": "src"
+    ".": "src"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1202,6 +1202,18 @@
       "integrity": "sha1-+4m2WpqAKBgz8LdHizpRBPiY67M=",
       "dev": true
     },
+    "maddoc-cli": {
+      "version": "file:madlib_modules/https___github_com_madlib_lang_maddoc_cli_archive_refs_heads_master_zip",
+      "requires": {
+        "sass": "^1.32.8"
+      }
+    },
+    "madmarkdown-renderer": {
+      "version": "file:madlib_modules/https___github_com_madlib_lang_madmarkdown_renderer_archive_refs_heads_master_zip",
+      "requires": {
+        "sass": "^1.32.6"
+      }
+    },
     "madui": {
       "version": "file:madlib_modules/https___github_com_madlib_lang_madui_archive_refs_heads_master_zip",
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1203,9 +1203,9 @@
       "dev": true
     },
     "madui": {
-      "version": "file:madlib_modules/https___github_com_madlib_lang_madui_archive_master_zip",
+      "version": "file:madlib_modules/https___github_com_madlib_lang_madui_archive_refs_heads_master_zip",
       "requires": {
-        "snabbdom": "^2.1.0"
+        "snabbdom": "^3.0.1"
       }
     },
     "merge": {
@@ -1695,9 +1695,9 @@
       "dev": true
     },
     "snabbdom": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/snabbdom/-/snabbdom-2.1.0.tgz",
-      "integrity": "sha512-3GPeO80A2/bob5ADrkRX8FtvW8kHbJ0aRb4XAN2MIN4bY2dprNJkhp87AgfjWgVhIkwgX9DOsuTLjWwBhMXMkQ=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snabbdom/-/snabbdom-3.0.1.tgz",
+      "integrity": "sha512-H4gKokDT1HPe3dlGyTihNw0NtEH9FxZy55MXp3ODM4O30NBRe+11veox1wf/CP9NfGcbStDM3BmO1DFC9/5wRw=="
     },
     "socket.io": {
       "version": "2.4.0",

--- a/src/Main.mad
+++ b/src/Main.mad
@@ -22,6 +22,7 @@ import {
   ul
 } from "MadUI"
 import { always } from "Function"
+import URL from "URL"
 
 import {
   State
@@ -42,7 +43,18 @@ import {
   Expression
 } from "./Parser/Documentation"
 
-import { processPath, getModulesToShow, ExpressionResult, TypeResult, ModuleResult, PathResult } from "./PathResolver"
+import {
+  processPath,
+  getModulesToShow,
+  ExpressionResult,
+  TypeResult,
+  AliasResult,
+  InterfaceResult,
+  InstanceResult,
+  ModuleResult,
+  PathResult
+} from "./PathResolver"
+
 
 parsedDocumentation = J.parse(parser, docJson)
 
@@ -51,7 +63,7 @@ initialState = where(parsedDocumentation)
   is Right modules: {
     modules,
     search: "",
-    path: getUrl(())
+    path: URL.decode(getUrl(()))
   }
 
 
@@ -87,11 +99,19 @@ ContentView = where
   is TypeResult moduleName t:
     <ul className="content__items">{Type(moduleName, t)}</ul>
 
+  is AliasResult moduleName t:
+    <ul className="content__items">{Alias(moduleName, t)}</ul>
+
+  is InterfaceResult moduleName t:
+    <ul className="content__items">{Interface(moduleName, t)}</ul>
+
+  is InstanceResult moduleName t:
+    <ul className="content__items">{Instance(moduleName, t)}</ul>
+
 DocApp :: State -> Element
 DocApp = (state) => {
   modulesInPath = getModulesToShow(state)
   pathResult = processPath(state)
-
   return (
     <div className="documentation">
       {Header(())}
@@ -105,7 +125,7 @@ DocApp = (state) => {
 }
 
 onUrlChanged(syncAction((state, event) => where(event)
-  is UrlEvent { url }: { ...state, path: url }
+  is UrlEvent { url }: { ...state, path: URL.decode(url) }
 ))
 
 render(DocApp, initialState, "app")

--- a/src/Main.mad
+++ b/src/Main.mad
@@ -1,282 +1,108 @@
-import {} from "Number"
-import { len, filter, flatten, first } from "List"
-import { fromMaybe } from "Maybe"
+import L from "List"
 import J from "Json"
 import { Right } from "Either"
-import { lines, split } from "String"
 import docJson from "./documentation.json"
 import {
-  Element,
   Action,
-  View,
-  h2,
+  Element,
+  UrlEvent,
   onInput,
   div,
-  span,
+  h2,
   input,
   className,
+  onUrlChanged,
+  syncAction,
+  getUrl,
   text,
+  p,
   placeholder,
   InputEvent,
   render,
   inputType,
-  li,
-  p,
   header,
   main,
   ul
 } from "MadUI"
 import IO from "IO"
 import { always } from "Function"
+import {} from "Compare"
+
+import {
+  State
+} from "./State"
+
+import { Expression } from "./Views/Expression"
+import { SideMenu } from "./Views/SideMenu"
+// import { Type } from "./Views/Type"
+// import { Alias } from "./Views/Alias"
+// import { Interface } from "./Views/Interface"
+// import { Instance } from "./Views/Instance"
 
 import {
   parser,
-  Expression,
-  Type,
-  Alias,
-  Interface,
-  Instance
+  Module,
+  Expression
 } from "./Parser/Documentation"
 
+import { computeViewType, getModulesToShow, ExpressionViewType, ModuleViewType, ViewType } from "./PathResolver"
 
 parsedDocumentation = J.parse(parser, docJson)
 
-
-sort :: (a -> a -> Number) -> List a -> List a
-sort = (fn, xs) => #- xs.sort(fn) -#
-
-getDocItemName :: DocItem -> String
-getDocItemName = where
-  is ExpressionItem _ def: def.name
-  is TypeItem _ def      : def.name
-  is AliasItem _ def     : def.name
-  is InterfaceItem _ def : def.name
-  is InstanceItem _ def  : def.declaration
-
-type DocItem
-  = ExpressionItem String Expression
-  | TypeItem String Type
-  | AliasItem String Alias
-  | InterfaceItem String Interface
-  | InstanceItem String Instance
-
-alias State = { docItems :: List DocItem, search :: String }
-
 initialState :: State
 initialState = where(parsedDocumentation)
-  is Right modules: pipe(
-    map((module) => [
-      ...map((exp) => ExpressionItem(module.name, exp), module.expressions),
-      ...map((typeDef) => TypeItem(module.name, typeDef), module.typeDeclarations),
-      ...map((aliasDef) => AliasItem(module.name, aliasDef), module.aliases),
-      ...map((interfac) => InterfaceItem(module.name, interfac), module.interfaces),
-      ...map((inst) => InstanceItem(module.name, inst), module.instances)
-    ]),
-    flatten,
-    (docItems) => ({ docItems: docItems, search: "" })
-  )(modules)
+  is Right modules: {
+    modules,
+    search: "",
+    path: getUrl(())
+  }
 
 
 handleInput :: Action State
 handleInput = (state, event) => where(event)
   is InputEvent e: [of(always({ ...state, search: e.target.value }))]
 
-DocApp :: View State
+
+ModuleView :: Module -> Element
+ModuleView = (module) =>
+  <div className="module">
+    <h2 className="module__title">{module.name}</h2>
+    <p className="module__description">{module.description}</p>
+    <ul>
+      {map(Expression(module.name), module.expressions)}
+    </ul>
+  </div>
+
+ContentView :: ViewType -> Element
+ContentView = where
+  is ModuleViewType modules:
+    <main className="documentation__content">
+      {map(ModuleView, modules)}
+    </main>
+
+  is ExpressionViewType moduleName exp:
+    <main className="documentation__content">
+      <ul>{Expression(moduleName, exp)}</ul>
+    </main>
+
+DocApp :: State -> Element
 DocApp = (state) => {
-  filteredItems = #- state.docItems.filter((s) => getDocItemName(s).match(state.search)) -#
+  modulesInPath = getModulesToShow(state)
+  vt = computeViewType(state)
 
   return (
     <div className="documentation">
       <header className="documentation__header">
         <input inputType="text" placeholder="What are you looking for?" className="search-field" onInput={handleInput} />
       </header>
-      <main className="documentation__content">
-        {DocItemList(filteredItems)}
-      </main>
+      {SideMenu(modulesInPath)}
+      {ContentView(vt)}
     </div>
   )
 }
 
-DocItemList :: View (List DocItem)
-DocItemList = (docItems) => <ul>{map(DocItem, docItems)}</ul>
-
-DocItem :: View DocItem
-DocItem = (docItem) => where(docItem)
-  is ExpressionItem _ _: ExpressionItemView(docItem)
-  is TypeItem _ _      : TypeItemView(docItem)
-  is AliasItem _ _     : AliasItemView(docItem)
-  is InterfaceItem _ _ : InterfaceItemView(docItem)
-  is InstanceItem _ _  : InstanceItemView(docItem)
-
-ExpressionItemView :: View DocItem
-ExpressionItemView = (docItem) => {
-  moduleName = where(docItem) is ExpressionItem n _  : n
-  definition = where(docItem) is ExpressionItem _ def: def
-  descriptionParagraphs = pipe(
-    .description,
-    lines,
-    map((desc) => <p>{desc}</p>)
-  )(definition)
-
-  return (
-    <li className="definition">
-      <div className="definition__etiquette">{`Function`}</div>
-      <h2 className="definition__title">
-        <span>{definition.name}</span>
-        <span className="definition__module">{moduleName}</span>
-      </h2>
-      <p><span className="definition__type">{definition.typing}</span></p>
-      <p className="definition__since">
-        Added in v{definition.since}
-      </p>
-      <div className="definition__description">{descriptionParagraphs}</div>
-      <p className={definition.example == "" ? "" : "definition__example"}>
-        {Example(definition.example)}
-      </p>
-    </li>
-  )
-}
-
-AliasItemView :: View DocItem
-AliasItemView = (docItem) => {
-  moduleName  = where(docItem) is AliasItem n _  : n
-  aliasDef    = where(docItem) is AliasItem _ def: def
-  aliasedType = aliasDef.aliasedType
-
-  return (
-    <li className="definition">
-      <div className="definition__etiquette">Alias</div>
-      <h2 className="definition__title">
-        <span>{aliasDef.name}</span>
-        <span className="definition__module">{moduleName}</span>
-      </h2>
-      <div className="definition__adt">
-        <span className="highlight">alias</span>
-        <span> {aliasDef.name}{aliasDef.params}</span>
-        <span className="definition__constructors">
-          <span className="definition__constructor">
-            <span className="highlight"> = </span>
-            <span>{aliasedType}</span>
-          </span>
-        </span>
-      </div>
-    </li>
-  )
-}
-
-InterfaceItemView :: View DocItem
-InterfaceItemView = (docItem) => {
-  moduleName   = where(docItem) is InterfaceItem n _  : n
-  interfaceDef = where(docItem) is InterfaceItem _ def: def
-  methods      = interfaceDef.methods
-  constraints  = interfaceDef.constraints
-  constraintElements =
-    if (constraints != "") {[
-        <span>{constraints}</span>,
-        <span className="highlight">{` => `}</span>
-    ]} else { [] }
-
-  return (
-    <li className="definition">
-      <div className="definition__etiquette">Interface</div>
-      <h2 className="definition__title">
-        <span>{interfaceDef.name}</span>
-        <span className="definition__module">{moduleName}</span>
-      </h2>
-      <div className="definition__interface">
-        <span className="highlight">interface </span>
-        <span>{constraintElements}</span>
-        <span>{interfaceDef.name} {interfaceDef.vars}</span>
-        <span className="highlight">{` {`}</span>
-        <div>{map((method) => <div>  {method}</div>, methods)}</div>
-        <span className="highlight">{`}`}</span>
-      </div>
-    </li>
-  )
-}
-
-InstanceItemView :: View DocItem
-InstanceItemView = (docItem) => {
-  moduleName   = where(docItem) is InstanceItem n _  : n
-  instanceDef  = where(docItem) is InstanceItem _ def: def
-  constraints  = instanceDef.constraints
-  constraintElements =
-    if (constraints != "") {[
-        <span>{constraints}</span>,
-        <span className="highlight">{` => `}</span>
-    ]} else { [] }
-
-  return (
-    <li className="definition">
-      <div className="definition__etiquette">Instance</div>
-      <h2 className="definition__title">
-        <span>{instanceDef.declaration}</span>
-        <span className="definition__module">{moduleName}</span>
-      </h2>
-      <div className="definition__interface">
-        <span className="highlight">instance </span>
-        <span>{constraintElements}</span>
-        <span>{instanceDef.declaration}</span>
-      </div>
-    </li>
-  )
-}
-
-TypeItemView :: View DocItem
-TypeItemView = (docItem) => {
-  moduleName     = where(docItem) is TypeItem n _  : n
-  typeDefinition = where(docItem) is TypeItem _ def: def
-  constructors   = typeDefinition.constructors
-  manyCtors      = len(constructors) > 1
-
-  renderedConstructors = manyCtors
-    ? ConstructorsView("=", constructors)
-    : [
-      <span className="definition__constructor">
-        <span className="highlight">= </span>
-        <span>{fromMaybe("???", first(constructors))}</span>
-      </span>
-    ]
-
-  return (
-    <li className="definition">
-      <div className="definition__etiquette">Type</div>
-      <h2 className="definition__title">
-        <span>{typeDefinition.name}</span>
-        <span className="definition__module">{moduleName}</span>
-      </h2>
-      <div className="definition__adt">
-        <span className="highlight">type</span>
-        <span> {typeDefinition.name} {typeDefinition.params}</span>
-        <span className="definition__constructors">{renderedConstructors}</span>
-      </div>
-    </li>
-  )
-}
-
-ConstructorsView :: String -> (List String) -> List Element
-ConstructorsView = (separator, items) => where(items)
-  is [ctor, ...more]: [ConstructorView(separator, ctor), ...ConstructorsView("|", more)]
-  is [ctor]         : [ConstructorView(separator, ctor)]
-  is []             : []
-
-ConstructorView :: String -> View String
-ConstructorView = (separator, constructor) =>
-  <div className="definition__constructor">
-    <span className="highlight">  {separator}</span>
-    <span> {constructor}</span>
-  </div>
-
-
-Example :: View String
-Example = (example) => {
-  lineList = split("\n", example)
-
-  return (
-    <div>
-      {map((l) => <div className="example__line">{l}</div>, lineList)}
-    </div>
-  )
-}
+onUrlChanged(syncAction((state, event) => where(event)
+  is UrlEvent { url }: { ...state, path: url }
+))
 
 render(DocApp, initialState, "app")

--- a/src/Main.mad
+++ b/src/Main.mad
@@ -6,27 +6,22 @@ import {
   Action,
   Element,
   UrlEvent,
-  onInput,
   div,
   h2,
-  input,
   className,
   onUrlChanged,
   syncAction,
   getUrl,
   text,
   p,
-  placeholder,
+  link,
+  to,
   InputEvent,
   render,
-  inputType,
-  header,
   main,
   ul
 } from "MadUI"
-import IO from "IO"
 import { always } from "Function"
-import {} from "Compare"
 
 import {
   State
@@ -34,10 +29,12 @@ import {
 
 import { Expression } from "./Views/Expression"
 import { SideMenu } from "./Views/SideMenu"
-// import { Type } from "./Views/Type"
-// import { Alias } from "./Views/Alias"
-// import { Interface } from "./Views/Interface"
-// import { Instance } from "./Views/Instance"
+import { Header } from "./Views/Header"
+import { Breadcrumbs } from "./Views/Breadcrumbs"
+import { Type } from "./Views/Type"
+import { Alias } from "./Views/Alias"
+import { Interface } from "./Views/Interface"
+import { Instance } from "./Views/Instance"
 
 import {
   parser,
@@ -45,7 +42,7 @@ import {
   Expression
 } from "./Parser/Documentation"
 
-import { computeViewType, getModulesToShow, ExpressionViewType, ModuleViewType, ViewType } from "./PathResolver"
+import { processPath, getModulesToShow, ExpressionResult, TypeResult, ModuleResult, PathResult } from "./PathResolver"
 
 parsedDocumentation = J.parse(parser, docJson)
 
@@ -66,37 +63,43 @@ handleInput = (state, event) => where(event)
 ModuleView :: Module -> Element
 ModuleView = (module) =>
   <div className="module">
-    <h2 className="module__title">{module.name}</h2>
+    <h2 className="module__title">
+      <link to={`/${module.name}`}>{module.name}</link>
+    </h2>
     <p className="module__description">{module.description}</p>
-    <ul>
+    <ul className="content__items">
+      {map(Type(module.name), module.typeDeclarations)}
+      {map(Alias(module.name), module.aliases)}
+      {map(Interface(module.name), module.interfaces)}
+      {map(Instance(module.name), module.instances)}
       {map(Expression(module.name), module.expressions)}
     </ul>
   </div>
 
-ContentView :: ViewType -> Element
+ContentView :: PathResult -> Element
 ContentView = where
-  is ModuleViewType modules:
-    <main className="documentation__content">
-      {map(ModuleView, modules)}
-    </main>
+  is ModuleResult modules:
+    <div>{map(ModuleView, modules)}</div>
 
-  is ExpressionViewType moduleName exp:
-    <main className="documentation__content">
-      <ul>{Expression(moduleName, exp)}</ul>
-    </main>
+  is ExpressionResult moduleName exp:
+    <ul className="content__items">{Expression(moduleName, exp)}</ul>
+
+  is TypeResult moduleName t:
+    <ul className="content__items">{Type(moduleName, t)}</ul>
 
 DocApp :: State -> Element
 DocApp = (state) => {
   modulesInPath = getModulesToShow(state)
-  vt = computeViewType(state)
+  pathResult = processPath(state)
 
   return (
     <div className="documentation">
-      <header className="documentation__header">
-        <input inputType="text" placeholder="What are you looking for?" className="search-field" onInput={handleInput} />
-      </header>
-      {SideMenu(modulesInPath)}
-      {ContentView(vt)}
+      {Header(())}
+      {SideMenu(state.modules)}
+      <main className="documentation__content">
+        {Breadcrumbs(state)}
+        {ContentView(pathResult)}
+      </main>
     </div>
   )
 }

--- a/src/Main.mad
+++ b/src/Main.mad
@@ -1,7 +1,7 @@
 import Json from "Json"
 import String from "String"
 import { Right } from "Either"
-import docJson from "./documentation.json"
+import docJson from "@/documentation.json"
 import type { Element } from "MadUI"
 import {
   UrlEvent,
@@ -22,21 +22,21 @@ import {
 } from "MadUI"
 import URL from "URL"
 
-import type { State } from "./State"
+import type { State } from "@/State"
 
-import { Expression } from "./Views/Expression"
-import { SideMenu } from "./Views/SideMenu"
-import { Header } from "./Views/Header"
-import { Breadcrumbs } from "./Views/Breadcrumbs"
-import { Type } from "./Views/Type"
-import { Alias } from "./Views/Alias"
-import { Interface } from "./Views/Interface"
-import { Instance } from "./Views/Instance"
+import { Expression } from "@/Views/Expression"
+import { SideMenu } from "@/Views/SideMenu"
+import { Header } from "@/Views/Header"
+import { Breadcrumbs } from "@/Views/Breadcrumbs"
+import { Type } from "@/Views/Type"
+import { Alias } from "@/Views/Alias"
+import { Interface } from "@/Views/Interface"
+import { Instance } from "@/Views/Instance"
 
-import type { Module } from "./Parser/Documentation"
-import { parser } from "./Parser/Documentation"
+import type { Module } from "@/Parser/Documentation"
+import { parser } from "@/Parser/Documentation"
 
-import type { PathResult } from "./PathResolver"
+import type { PathResult } from "@/PathResolver"
 import {
   processPath,
   getModulesToShow,
@@ -46,9 +46,9 @@ import {
   InterfaceResult,
   InstanceResult,
   ModuleResult
-} from "./PathResolver"
+} from "@/PathResolver"
 
-import { renderMarkdown } from "./Markdown"
+import { renderMarkdown } from "@/Markdown"
 
 
 parsedDocumentation = Json.parse(parser, docJson)

--- a/src/Main.mad
+++ b/src/Main.mad
@@ -1,10 +1,9 @@
-import L from "List"
-import J from "Json"
+import Json from "Json"
+import String from "String"
 import { Right } from "Either"
 import docJson from "./documentation.json"
+import type { Element } from "MadUI"
 import {
-  Action,
-  Element,
   UrlEvent,
   div,
   h2,
@@ -13,20 +12,17 @@ import {
   syncAction,
   getUrl,
   text,
+  empty,
   p,
   link,
   to,
-  InputEvent,
   render,
   main,
   ul
 } from "MadUI"
-import { always } from "Function"
 import URL from "URL"
 
-import {
-  State
-} from "./State"
+import type { State } from "./State"
 
 import { Expression } from "./Views/Expression"
 import { SideMenu } from "./Views/SideMenu"
@@ -37,12 +33,10 @@ import { Alias } from "./Views/Alias"
 import { Interface } from "./Views/Interface"
 import { Instance } from "./Views/Instance"
 
-import {
-  parser,
-  Module,
-  Expression
-} from "./Parser/Documentation"
+import type { Module } from "./Parser/Documentation"
+import { parser } from "./Parser/Documentation"
 
+import type { PathResult } from "./PathResolver"
 import {
   processPath,
   getModulesToShow,
@@ -51,12 +45,13 @@ import {
   AliasResult,
   InterfaceResult,
   InstanceResult,
-  ModuleResult,
-  PathResult
+  ModuleResult
 } from "./PathResolver"
 
+import { renderMarkdown } from "./Markdown"
 
-parsedDocumentation = J.parse(parser, docJson)
+
+parsedDocumentation = Json.parse(parser, docJson)
 
 initialState :: State
 initialState = where(parsedDocumentation)
@@ -67,18 +62,17 @@ initialState = where(parsedDocumentation)
   }
 
 
-handleInput :: Action State
-handleInput = (state, event) => where(event)
-  is InputEvent e: [of(always({ ...state, search: e.target.value }))]
-
-
 ModuleView :: Module -> Element
 ModuleView = (module) =>
   <div className="module">
     <h2 className="module__title">
       <link to={`/${module.name}`}>{module.name}</link>
     </h2>
-    <p className="module__description">{module.description}</p>
+    {
+      String.isEmpty(module.description)
+        ? <empty />
+        : <p className="module__description">{renderMarkdown(module.description)}</p>
+    }
     <ul className="content__items">
       {map(Type(module.name), module.typeDeclarations)}
       {map(Alias(module.name), module.aliases)}
@@ -115,7 +109,7 @@ DocApp = (state) => {
   return (
     <div className="documentation">
       {Header(())}
-      {SideMenu(state.modules)}
+      {SideMenu(state.search, state.modules)}
       <main className="documentation__content">
         {Breadcrumbs(state)}
         {ContentView(pathResult)}

--- a/src/Markdown.mad
+++ b/src/Markdown.mad
@@ -1,0 +1,17 @@
+import type { Element } from "MadUI"
+import {
+  className,
+  text,
+  link,
+  to
+} from "MadUI"
+import type { Config } from "MarkdownRenderer"
+import { renderMarkdownWithConfig, defaultConfig, setLinkView } from "MarkdownRenderer"
+
+mdConfig :: Config
+mdConfig = pipe(
+  setLinkView((txt, url) => <link className="markdown__link" to={url}>{txt}</link>)
+)(defaultConfig)
+
+renderMarkdown :: String -> Element
+export renderMarkdown = renderMarkdownWithConfig(mdConfig)

--- a/src/Parser/Documentation.mad
+++ b/src/Parser/Documentation.mad
@@ -1,27 +1,39 @@
-import J from "Json"
+import Json from "Json"
 
 export alias Instance = {
   declaration :: String,
-  constraints :: String
+  constraints :: String,
+  description  :: String,
+  since        :: String,
+  example      :: String
 }
 
 export alias Interface = {
   name        :: String,
   vars        :: String,
   constraints :: String,
-  methods     :: List String
+  methods     :: List String,
+  description  :: String,
+  since        :: String,
+  example      :: String
 }
 
 export alias Alias = {
   name        :: String,
   params      :: String,
-  aliasedType :: String
+  aliasedType :: String,
+  description  :: String,
+  since        :: String,
+  example      :: String
 }
 
 export alias Type = {
   name         :: String,
   params       :: String,
-  constructors :: List String
+  constructors :: List String,
+  description  :: String,
+  since        :: String,
+  example      :: String
 }
 
 export alias Expression = {
@@ -45,19 +57,21 @@ export alias Module = {
 
 export alias Documentation = List Module
 
-makeInstance :: String -> String -> Instance
-makeInstance = (declaration, constraints) => ({ declaration, constraints })
+makeInstance :: String -> String -> String -> String -> String -> Instance
+makeInstance = (declaration, constraints, description, since, example) =>
+  ({ declaration, constraints, description, since, example })
 
-makeInterface :: String -> String -> String -> List String -> Interface
-makeInterface = (name, vars, constraints, methods) => ({
-  name, vars, constraints, methods
-})
+makeInterface :: String -> String -> String -> List String -> String -> String -> String -> Interface
+makeInterface = (name, vars, constraints, methods, description, since, example) =>
+  ({ name, vars, constraints, methods, description, since, example })
 
-makeAlias :: String -> String -> String -> Alias
-makeAlias = (name, params, aliasedType) => ({ name, params, aliasedType })
+makeAlias :: String -> String -> String -> String -> String -> String -> Alias
+makeAlias = (name, params, aliasedType, description, since, example) =>
+  ({ name, params, aliasedType, description, since, example })
 
-makeType :: String -> String -> List String -> Type
-makeType = (name, params, constructors) => ({ name, params, constructors })
+makeType :: String -> String -> List String -> String -> String -> String -> Type
+makeType = (name, params, constructors, description, since, example) =>
+  ({ name, params, constructors, description, since, example })
 
 makeExpression :: String -> String -> String -> String -> String -> Expression
 makeExpression = (name, description, typing, since, example) => ({
@@ -74,56 +88,75 @@ makeModule :: String
   -> List Instance
   -> Module
 makeModule = (path, name, description, expressions, typeDeclarations, aliases, interfaces, instances) => ({
-  path, name, description, expressions, typeDeclarations, aliases, interfaces, instances
+  path,
+  name,
+  description,
+  expressions,
+  typeDeclarations,
+  aliases,
+  interfaces,
+  instances
 })
 
-parser :: J.Parser Documentation
-export parser = J.field("modules", J.list(
-  J.map8(
+parser :: Json.Parser Documentation
+export parser = Json.field("modules", Json.list(
+  Json.map8(
     makeModule,
-    J.field("path", J.string),
-    J.field("moduleName", J.string),
-    J.field("description", J.string),
-    J.field("expressions", J.list(
-      J.map5(
+    Json.field("path", Json.string),
+    Json.field("moduleName", Json.string),
+    Json.field("description", Json.string),
+    Json.field("expressions", Json.list(
+      Json.map5(
         makeExpression,
-        J.field("name", J.string),
-        J.field("description", J.string),
-        J.field("type", J.string),
-        J.field("since", J.string),
-        J.field("example", J.string)
+        Json.field("name", Json.string),
+        Json.field("description", Json.string),
+        Json.field("type", Json.string),
+        Json.field("since", Json.string),
+        Json.field("example", Json.string)
       )
     )),
-    J.field("typeDeclarations", J.list(
-      J.map3(
+    Json.field("typeDeclarations", Json.list(
+      Json.map6(
         makeType,
-        J.field("name", J.string),
-        J.field("params", J.string),
-        J.field("constructors", J.list(J.string))
+        Json.field("name", Json.string),
+        Json.field("params", Json.string),
+        Json.field("constructors", Json.list(Json.string)),
+        Json.field("description", Json.string),
+        Json.field("since", Json.string),
+        Json.field("example", Json.string)
       )
     )),
-    J.field("aliases", J.list(
-      J.map3(
+    Json.field("aliases", Json.list(
+      Json.map6(
         makeAlias,
-        J.field("name", J.string),
-        J.field("params", J.string),
-        J.field("aliasedType", J.string)
+        Json.field("name", Json.string),
+        Json.field("params", Json.string),
+        Json.field("aliasedType", Json.string),
+        Json.field("description", Json.string),
+        Json.field("since", Json.string),
+        Json.field("example", Json.string)
       )
     )),
-    J.field("interfaces", J.list(
-      J.map4(
+    Json.field("interfaces", Json.list(
+      Json.map7(
         makeInterface,
-        J.field("name", J.string),
-        J.field("vars", J.string),
-        J.field("constraints", J.string),
-        J.field("methods", J.list(J.string))
+        Json.field("name", Json.string),
+        Json.field("vars", Json.string),
+        Json.field("constraints", Json.string),
+        Json.field("methods", Json.list(Json.string)),
+        Json.field("description", Json.string),
+        Json.field("since", Json.string),
+        Json.field("example", Json.string)
       )
     )),
-    J.field("instances", J.list(
-      J.map2(
+    Json.field("instances", Json.list(
+      Json.map5(
         makeInstance,
-        J.field("declaration", J.string),
-        J.field("constraints", J.string)
+        Json.field("declaration", Json.string),
+        Json.field("constraints", Json.string),
+        Json.field("description", Json.string),
+        Json.field("since", Json.string),
+        Json.field("example", Json.string)
       )
     ))
   )

--- a/src/Parser/Documentation.mad
+++ b/src/Parser/Documentation.mad
@@ -33,14 +33,14 @@ export alias Expression = {
 }
 
 export alias Module = {
-  path :: String,
-  name :: String,
-  description :: String,
-  expressions :: List Expression,
+  path             :: String,
+  name             :: String,
+  description      :: String,
+  expressions      :: List Expression,
   typeDeclarations :: List Type,
-  aliases :: List Alias,
-  interfaces :: List Interface,
-  instances :: List Instance
+  aliases          :: List Alias,
+  interfaces       :: List Interface,
+  instances        :: List Instance
 }
 
 export alias Documentation = List Module
@@ -65,14 +65,14 @@ makeExpression = (name, description, typing, since, example) => ({
 })
 
 makeModule :: String
-           -> String
-           -> String
-           -> List Expression
-           -> List Type
-           -> List Alias
-           -> List Interface
-           -> List Instance
-           -> Module
+  -> String
+  -> String
+  -> List Expression
+  -> List Type
+  -> List Alias
+  -> List Interface
+  -> List Instance
+  -> Module
 makeModule = (path, name, description, expressions, typeDeclarations, aliases, interfaces, instances) => ({
   path, name, description, expressions, typeDeclarations, aliases, interfaces, instances
 })

--- a/src/PathResolver.mad
+++ b/src/PathResolver.mad
@@ -1,43 +1,50 @@
-import L from "List"
+import List from "List"
 import J from "Json"
 import { Just, Nothing } from "Maybe"
-import IO from "IO"
 import { always, any, equals, ifElse } from "Function"
 import { drop, split, toLower, match, len } from "String"
-import { isRootPathOf, canonicalizePath } from "FilePath/Posix"
+import { isRootPathOf, canonicalizePath, FilePath } from "FilePath/Posix"
 import {} from "Compare"
 
 import {
   State
 } from "./State"
-
 import { Expression } from "./Views/Expression"
-
 import {
   Module,
-  Expression
+  Expression,
+  Type
 } from "./Parser/Documentation"
 
-export type ViewType
-  = ModuleViewType (List Module)
-  | ExpressionViewType String Expression
+import IO from "IO"
 
-
+export type PathResult
+  = ModuleResult (List Module)
+  | ExpressionResult String Expression
+  | TypeResult String Type
+  | NotFound
 
 
 filterByPath :: String -> List Module -> List Module
 filterByPath = (path) => {
   canPath = canonicalizePath(path)
-  return L.filter((module) =>
+
+  return List.filter((module) =>
     pipe(
       .name,
       toLower,
       ifElse(
         isRootPathOf(drop(1, toLower(canPath))),
-        always(true),
+        always(
+          !List.isEmpty(module.expressions)
+          || !List.isEmpty(module.typeDeclarations)
+        ),
         pipe(
-          always(module.expressions),
-          map(pipe(.name, mappend(`${module.name}/`), toLower)),
+          always([
+            ...map(.name, module.expressions),
+            ...map(.name, module.typeDeclarations)
+          ]),
+          map(pipe(mappend(`${module.name}/`), toLower)),
           any(isRootPathOf(drop(1, toLower(canPath))))
         )
       )
@@ -51,15 +58,15 @@ export getModulesToShow = (state) => pipe(
   filterByPath(state.path),
   map((module) => ({
     ...module,
-    expressions: L.filter(pipe(.name, match(state.search)), module.expressions)
+    expressions: List.filter(pipe(.name, match(state.search)), module.expressions)
   }))
 )(state.modules)
 
 isItemView :: String -> List Module -> Boolean
 isItemView = (path) => ifElse(
-  pipe(L.len, equals(1)),
+  pipe(List.len, equals(1)),
   pipe(
-    L.first,
+    List.first,
     where
       is Just m : len(canonicalizePath(path)) > len(`/${m.name}`)
       is Nothing: false
@@ -67,19 +74,46 @@ isItemView = (path) => ifElse(
   always(false)
 )
 
-computeViewType :: State -> ViewType
-export computeViewType = (state) => pipe(
+
+findExpression :: FilePath -> Module -> PathResult
+findExpression = (path, module) => pipe(
+  .expressions,
+  List.find((e) => Just(e.name) == List.last(split("/", path))),
+  where
+    is Just found: ExpressionResult(module.name, found)
+    is Nothing   : NotFound
+)(module)
+
+findType :: FilePath -> Module -> PathResult
+findType = (path, module) => pipe(
+  .typeDeclarations,
+  List.find((e) => Just(e.name) == List.last(split("/", path))),
+  where
+    is Just found: TypeResult(module.name, found)
+    is Nothing   : NotFound,
+  IO.log
+)(module)
+
+findItem :: FilePath -> Module -> PathResult
+findItem = (path, module) => pipe(
+  findExpression(path),
+  where
+    is NotFound: findType(path, module)
+    is a       : a,
+  IO.log
+)(module)
+
+
+processPath :: State -> PathResult
+export processPath = (state) => pipe(
   getModulesToShow,
   ifElse(
     isItemView(state.path),
     pipe(
-      L.first,
-      where is Just m: pipe(
-        .expressions,
-        L.find((e) => Just(e.name) == L.last(split("/", state.path))),
-        where is Just found: ExpressionViewType(m.name, found)
-      )(m)
+      List.first,
+      where is Just m: findItem(state.path, m)
     ),
-    ModuleViewType
-  )
+    ModuleResult
+  ),
+  IO.log
 )(state)

--- a/src/PathResolver.mad
+++ b/src/PathResolver.mad
@@ -6,7 +6,7 @@ import type { FilePath } from "FilePath/Posix"
 import { isRootPathOf, canonicalizePath } from "FilePath/Posix"
 import {} from "Compare"
 
-import type { State } from "./State"
+import type { State } from "@/State"
 import type {
   Module,
   Expression,
@@ -14,7 +14,7 @@ import type {
   Interface,
   Instance,
   Type
-} from "./Parser/Documentation"
+} from "@/Parser/Documentation"
 
 
 

--- a/src/PathResolver.mad
+++ b/src/PathResolver.mad
@@ -13,15 +13,21 @@ import { Expression } from "./Views/Expression"
 import {
   Module,
   Expression,
+  Alias,
+  Interface,
+  Instance,
   Type
 } from "./Parser/Documentation"
 
-import IO from "IO"
+
 
 export type PathResult
   = ModuleResult (List Module)
   | ExpressionResult String Expression
   | TypeResult String Type
+  | AliasResult String Alias
+  | InterfaceResult String Interface
+  | InstanceResult String Instance
   | NotFound
 
 
@@ -42,7 +48,10 @@ filterByPath = (path) => {
         pipe(
           always([
             ...map(.name, module.expressions),
-            ...map(.name, module.typeDeclarations)
+            ...map(.name, module.typeDeclarations),
+            ...map(.name, module.aliases),
+            ...map(.name, module.interfaces),
+            ...map(.declaration, module.instances)
           ]),
           map(pipe(mappend(`${module.name}/`), toLower)),
           any(isRootPathOf(drop(1, toLower(canPath))))
@@ -90,18 +99,58 @@ findType = (path, module) => pipe(
   List.find((e) => Just(e.name) == List.last(split("/", path))),
   where
     is Just found: TypeResult(module.name, found)
-    is Nothing   : NotFound,
-  IO.log
+    is Nothing   : NotFound
 )(module)
 
-findItem :: FilePath -> Module -> PathResult
-findItem = (path, module) => pipe(
-  findExpression(path),
+findAlias :: FilePath -> Module -> PathResult
+findAlias = (path, module) => pipe(
+  .aliases,
+  List.find((e) => Just(e.name) == List.last(split("/", path))),
   where
-    is NotFound: findType(path, module)
-    is a       : a,
-  IO.log
+    is Just found: AliasResult(module.name, found)
+    is Nothing   : NotFound
 )(module)
+
+findInterface :: FilePath -> Module -> PathResult
+findInterface = (path, module) => pipe(
+  .interfaces,
+  List.find((e) => Just(e.name) == List.last(split("/", path))),
+  where
+    is Just found: InterfaceResult(module.name, found)
+    is Nothing   : NotFound
+)(module)
+
+findInstance :: FilePath -> Module -> PathResult
+findInstance = (path, module) => pipe(
+  .instances,
+  List.find((e) => Just(e.declaration) == List.last(split("/", path))),
+  where
+    is Just found: InstanceResult(module.name, found)
+    is Nothing   : NotFound
+)(module)
+
+
+alias Finder = FilePath -> Module -> PathResult
+
+_findItem :: List Finder -> FilePath -> Module -> PathResult
+_findItem = (finders, path, module) => where(finders) {
+  is [try, ...others]:
+    where(try(path, module)) {
+      is NotFound: _findItem(others, path, module)
+      is found   : found
+    }
+
+  is []: NotFound
+}
+
+findItem :: FilePath -> Module -> PathResult
+findItem = _findItem([
+  findInstance,
+  findExpression,
+  findType,
+  findAlias,
+  findInterface
+])
 
 
 processPath :: State -> PathResult
@@ -114,6 +163,5 @@ export processPath = (state) => pipe(
       where is Just m: findItem(state.path, m)
     ),
     ModuleResult
-  ),
-  IO.log
+  )
 )(state)

--- a/src/PathResolver.mad
+++ b/src/PathResolver.mad
@@ -1,16 +1,13 @@
 import List from "List"
-import J from "Json"
 import { Just, Nothing } from "Maybe"
 import { always, any, equals, ifElse } from "Function"
-import { drop, split, toLower, match, len } from "String"
-import { isRootPathOf, canonicalizePath, FilePath } from "FilePath/Posix"
+import { drop, split, toLower, len } from "String"
+import type { FilePath } from "FilePath/Posix"
+import { isRootPathOf, canonicalizePath } from "FilePath/Posix"
 import {} from "Compare"
 
-import {
-  State
-} from "./State"
-import { Expression } from "./Views/Expression"
-import {
+import type { State } from "./State"
+import type {
   Module,
   Expression,
   Alias,
@@ -44,6 +41,9 @@ filterByPath = (path) => {
         always(
           !List.isEmpty(module.expressions)
           || !List.isEmpty(module.typeDeclarations)
+          || !List.isEmpty(module.aliases)
+          || !List.isEmpty(module.interfaces)
+          || !List.isEmpty(module.instances)
         ),
         pipe(
           always([
@@ -64,12 +64,9 @@ filterByPath = (path) => {
 
 getModulesToShow :: State -> List Module
 export getModulesToShow = (state) => pipe(
-  filterByPath(state.path),
-  map((module) => ({
-    ...module,
-    expressions: List.filter(pipe(.name, match(state.search)), module.expressions)
-  }))
-)(state.modules)
+  .modules,
+  filterByPath(state.path)
+)(state)
 
 isItemView :: String -> List Module -> Boolean
 isItemView = (path) => ifElse(
@@ -83,51 +80,17 @@ isItemView = (path) => ifElse(
   always(false)
 )
 
-
-findExpression :: FilePath -> Module -> PathResult
-findExpression = (path, module) => pipe(
-  .expressions,
-  List.find((e) => Just(e.name) == List.last(split("/", path))),
+tryItemByKind :: (a -> b -> PathResult)
+  -> (b -> String)
+  -> List b
+  -> FilePath
+  -> { ...module, name :: a } -> PathResult
+tryItemByKind = (constructor, getName, items, path, module) => pipe(
+  List.find((e) => Just(getName(e)) == List.last(split("/", path))),
   where
-    is Just found: ExpressionResult(module.name, found)
+    is Just found: constructor(module.name, found)
     is Nothing   : NotFound
-)(module)
-
-findType :: FilePath -> Module -> PathResult
-findType = (path, module) => pipe(
-  .typeDeclarations,
-  List.find((e) => Just(e.name) == List.last(split("/", path))),
-  where
-    is Just found: TypeResult(module.name, found)
-    is Nothing   : NotFound
-)(module)
-
-findAlias :: FilePath -> Module -> PathResult
-findAlias = (path, module) => pipe(
-  .aliases,
-  List.find((e) => Just(e.name) == List.last(split("/", path))),
-  where
-    is Just found: AliasResult(module.name, found)
-    is Nothing   : NotFound
-)(module)
-
-findInterface :: FilePath -> Module -> PathResult
-findInterface = (path, module) => pipe(
-  .interfaces,
-  List.find((e) => Just(e.name) == List.last(split("/", path))),
-  where
-    is Just found: InterfaceResult(module.name, found)
-    is Nothing   : NotFound
-)(module)
-
-findInstance :: FilePath -> Module -> PathResult
-findInstance = (path, module) => pipe(
-  .instances,
-  List.find((e) => Just(e.declaration) == List.last(split("/", path))),
-  where
-    is Just found: InstanceResult(module.name, found)
-    is Nothing   : NotFound
-)(module)
+)(items)
 
 
 alias Finder = FilePath -> Module -> PathResult
@@ -144,13 +107,13 @@ _findItem = (finders, path, module) => where(finders) {
 }
 
 findItem :: FilePath -> Module -> PathResult
-findItem = _findItem([
-  findInstance,
-  findExpression,
-  findType,
-  findAlias,
-  findInterface
-])
+findItem = (path, module) => _findItem([
+  tryItemByKind(ExpressionResult, .name, module.expressions),
+  tryItemByKind(TypeResult, .name, module.typeDeclarations),
+  tryItemByKind(AliasResult, .name, module.aliases),
+  tryItemByKind(InterfaceResult, .name, module.interfaces),
+  tryItemByKind(InstanceResult, .declaration, module.instances)
+], path, module)
 
 
 processPath :: State -> PathResult

--- a/src/PathResolver.mad
+++ b/src/PathResolver.mad
@@ -1,0 +1,85 @@
+import L from "List"
+import J from "Json"
+import { Just, Nothing } from "Maybe"
+import IO from "IO"
+import { always, any, equals, ifElse } from "Function"
+import { drop, split, toLower, match, len } from "String"
+import { isRootPathOf, canonicalizePath } from "FilePath/Posix"
+import {} from "Compare"
+
+import {
+  State
+} from "./State"
+
+import { Expression } from "./Views/Expression"
+
+import {
+  Module,
+  Expression
+} from "./Parser/Documentation"
+
+export type ViewType
+  = ModuleViewType (List Module)
+  | ExpressionViewType String Expression
+
+
+
+
+filterByPath :: String -> List Module -> List Module
+filterByPath = (path) => {
+  canPath = canonicalizePath(path)
+  return L.filter((module) =>
+    pipe(
+      .name,
+      toLower,
+      ifElse(
+        isRootPathOf(drop(1, toLower(canPath))),
+        always(true),
+        pipe(
+          always(module.expressions),
+          map(pipe(.name, mappend(`${module.name}/`), toLower)),
+          any(isRootPathOf(drop(1, toLower(canPath))))
+        )
+      )
+    )(module)
+  )
+}
+
+
+getModulesToShow :: State -> List Module
+export getModulesToShow = (state) => pipe(
+  filterByPath(state.path),
+  map((module) => ({
+    ...module,
+    expressions: L.filter(pipe(.name, match(state.search)), module.expressions)
+  }))
+)(state.modules)
+
+isItemView :: String -> List Module -> Boolean
+isItemView = (path) => ifElse(
+  pipe(L.len, equals(1)),
+  pipe(
+    L.first,
+    where
+      is Just m : len(canonicalizePath(path)) > len(`/${m.name}`)
+      is Nothing: false
+  ),
+  always(false)
+)
+
+computeViewType :: State -> ViewType
+export computeViewType = (state) => pipe(
+  getModulesToShow,
+  ifElse(
+    isItemView(state.path),
+    pipe(
+      L.first,
+      where is Just m: pipe(
+        .expressions,
+        L.find((e) => Just(e.name) == L.last(split("/", state.path))),
+        where is Just found: ExpressionViewType(m.name, found)
+      )(m)
+    ),
+    ModuleViewType
+  )
+)(state)

--- a/src/State.mad
+++ b/src/State.mad
@@ -1,4 +1,4 @@
-import { Module } from "./Parser/Documentation"
+import type { Module } from "./Parser/Documentation"
 
 export alias State = {
   modules :: List Module,

--- a/src/State.mad
+++ b/src/State.mad
@@ -1,0 +1,7 @@
+import { Module } from "./Parser/Documentation"
+
+export alias State = {
+  modules :: List Module,
+  search :: String,
+  path :: String
+}

--- a/src/State.mad
+++ b/src/State.mad
@@ -1,4 +1,4 @@
-import type { Module } from "./Parser/Documentation"
+import type { Module } from "@/Parser/Documentation"
 
 export alias State = {
   modules :: List Module,

--- a/src/Views/Alias.mad
+++ b/src/Views/Alias.mad
@@ -8,13 +8,13 @@ import {
 } from "MadUI"
 import String from "String"
 
-import { Etiquette } from "./Etiquette"
-import { Title } from "./Title"
-import { Since } from "./Since"
-import { Description } from "./Description"
-import { Example } from "./Example"
+import { Etiquette } from "@/Views/Etiquette"
+import { Title } from "@/Views/Title"
+import { Since } from "@/Views/Since"
+import { Description } from "@/Views/Description"
+import { Example } from "@/Views/Example"
 
-import type { Alias } from "../Parser/Documentation"
+import type { Alias } from "@/Parser/Documentation"
 
 
 Alias :: String -> Alias -> Element

--- a/src/Views/Alias.mad
+++ b/src/Views/Alias.mad
@@ -6,7 +6,7 @@ import {
   text,
   li
 } from "MadUI"
-import IO from "IO"
+import String from "String"
 
 import { Etiquette } from "./Etiquette"
 import { Title } from "./Title"
@@ -17,6 +17,9 @@ import { Alias } from "../Parser/Documentation"
 Alias :: String -> Alias -> Element
 export Alias = (moduleName, aliasDef) => {
   aliasedType = aliasDef.aliasedType
+  params = String.isEmpty(aliasDef.params)
+    ? ""
+    : ` ${aliasDef.params}`
 
   return (
     <li className="definition">
@@ -26,7 +29,7 @@ export Alias = (moduleName, aliasDef) => {
       ]}
       <div className="definition__adt">
         <span className="highlight">alias</span>
-        <span> {aliasDef.name}{aliasDef.params}</span>
+        <span> {aliasDef.name}{params}</span>
         <span className="definition__constructors">
           <span className="definition__constructor">
             <span className="highlight"> = </span>

--- a/src/Views/Alias.mad
+++ b/src/Views/Alias.mad
@@ -1,0 +1,39 @@
+import {
+  Element,
+  div,
+  span,
+  className,
+  text,
+  li
+} from "MadUI"
+import IO from "IO"
+
+import { Etiquette } from "./Etiquette"
+import { Title } from "./Title"
+
+import { Alias } from "../Parser/Documentation"
+
+
+Alias :: String -> Alias -> Element
+export Alias = (moduleName, aliasDef) => {
+  aliasedType = aliasDef.aliasedType
+
+  return (
+    <li className="definition">
+      {[
+          Etiquette("Alias"),
+          Title(aliasDef.name, moduleName)
+      ]}
+      <div className="definition__adt">
+        <span className="highlight">alias</span>
+        <span> {aliasDef.name}{aliasDef.params}</span>
+        <span className="definition__constructors">
+          <span className="definition__constructor">
+            <span className="highlight"> = </span>
+            <span>{aliasedType}</span>
+          </span>
+        </span>
+      </div>
+    </li>
+  )
+}

--- a/src/Views/Alias.mad
+++ b/src/Views/Alias.mad
@@ -1,5 +1,5 @@
+import type { Element } from "MadUI"
 import {
-  Element,
   div,
   span,
   className,
@@ -10,8 +10,11 @@ import String from "String"
 
 import { Etiquette } from "./Etiquette"
 import { Title } from "./Title"
+import { Since } from "./Since"
+import { Description } from "./Description"
+import { Example } from "./Example"
 
-import { Alias } from "../Parser/Documentation"
+import type { Alias } from "../Parser/Documentation"
 
 
 Alias :: String -> Alias -> Element
@@ -37,6 +40,11 @@ export Alias = (moduleName, aliasDef) => {
           </span>
         </span>
       </div>
+      {[
+          Since(aliasDef),
+          Description(aliasDef),
+          Example(aliasDef)
+      ]}
     </li>
   )
 }

--- a/src/Views/Breadcrumbs.mad
+++ b/src/Views/Breadcrumbs.mad
@@ -14,7 +14,7 @@ import { snd } from "Tuple"
 import {} from "Number"
 import { canonicalizePath, joinPath, splitPath } from "FilePath/Posix"
 
-import type { State } from "../State"
+import type { State } from "@/State"
 
 
 type Breadcrumb = Breadcrumb String String

--- a/src/Views/Breadcrumbs.mad
+++ b/src/Views/Breadcrumbs.mad
@@ -1,5 +1,5 @@
+import type { Element } from "MadUI"
 import {
-  Element,
   key,
   link,
   to,
@@ -14,7 +14,7 @@ import { snd } from "Tuple"
 import {} from "Number"
 import { canonicalizePath, joinPath, splitPath } from "FilePath/Posix"
 
-import { State } from "../State"
+import type { State } from "../State"
 
 
 type Breadcrumb = Breadcrumb String String

--- a/src/Views/Breadcrumbs.mad
+++ b/src/Views/Breadcrumbs.mad
@@ -1,0 +1,71 @@
+import {
+  Element,
+  key,
+  link,
+  to,
+  className,
+  li,
+  text,
+  span,
+  ul
+} from "MadUI"
+import { append, intercalateWithIndex, reduce } from "List"
+import { snd } from "Tuple"
+import {} from "Number"
+import { canonicalizePath, joinPath, splitPath } from "FilePath/Posix"
+
+import { State } from "../State"
+
+
+type Breadcrumb = Breadcrumb String String
+
+getLink = where is Breadcrumb _ l: l
+getName = where is Breadcrumb l _: l
+
+
+generateBreadcrumbName :: String -> String
+generateBreadcrumbName = pipe(
+  canonicalizePath,
+  (pathSegment) => pathSegment == "/" || pathSegment == ""
+    ? "home"
+    : pathSegment
+)
+
+computeBreadcrumbs :: State -> List Breadcrumb
+computeBreadcrumbs = pipe(
+  .path,
+  splitPath,
+  reduce((acc, pathSegment) =>
+    where(acc) is <prevPath, breadcrumbs>: pipe(
+      append(pathSegment),
+      joinPath,
+      (path) => <
+        path,
+        append(
+          Breadcrumb(generateBreadcrumbName(pathSegment), path),
+          breadcrumbs
+        )
+      >
+    )([prevPath]),
+    <"", []>
+  ),
+  snd
+)
+
+BreadcrumbItem :: Breadcrumb -> Element
+BreadcrumbItem = (breadcrumb) =>
+  <li className="breadcrumbs__item" key={getLink(breadcrumb)}>
+    <link to={getLink(breadcrumb)}>{getName(breadcrumb)}</link>
+  </li>
+
+Breadcrumbs :: State -> Element
+export Breadcrumbs = pipe(
+  computeBreadcrumbs,
+  map(BreadcrumbItem),
+  intercalateWithIndex((i) =>
+    <span className="breadcrumbs__separator" key={`sep-${show(i)}`}>
+      /
+    </span>
+  ),
+  (breadcrumbs) => <ul className="breadcrumbs">{breadcrumbs}</ul>
+)

--- a/src/Views/Description.mad
+++ b/src/Views/Description.mad
@@ -4,7 +4,7 @@ import {
   className,
   text
 } from "MadUI"
-import { renderMarkdown } from "../Markdown"
+import { renderMarkdown } from "@/Markdown"
 
 
 Description :: { ...a, description :: String } -> Element

--- a/src/Views/Description.mad
+++ b/src/Views/Description.mad
@@ -1,16 +1,15 @@
+import type { Element } from "MadUI"
 import {
-    Element,
-    div,
-    className,
-    text,
-    p
-  } from "MadUI"
-  import { lines } from "String"
+  div,
+  className,
+  text
+} from "MadUI"
+import { renderMarkdown } from "../Markdown"
 
-Description :: { description :: String } -> Element
+
+Description :: { ...a, description :: String } -> Element
 export Description = pipe(
   .description,
-  lines,
-  map((desc) => <p>{desc}</p>),
-  (paragraphs) => <div className="definition__description">{paragraphs}</div>
+  renderMarkdown,
+  (content) => <div className="definition__description">{content}</div>
 )

--- a/src/Views/Description.mad
+++ b/src/Views/Description.mad
@@ -1,0 +1,16 @@
+import {
+    Element,
+    div,
+    className,
+    text,
+    p
+  } from "MadUI"
+  import { lines } from "String"
+
+Description :: { description :: String } -> Element
+export Description = pipe(
+  .description,
+  lines,
+  map((desc) => <p>{desc}</p>),
+  (paragraphs) => <div className="definition__description">{paragraphs}</div>
+)

--- a/src/Views/Etiquette.mad
+++ b/src/Views/Etiquette.mad
@@ -1,5 +1,5 @@
+import type { Element } from "MadUI"
 import {
-  Element,
   div,
   className,
   text

--- a/src/Views/Etiquette.mad
+++ b/src/Views/Etiquette.mad
@@ -1,0 +1,13 @@
+import {
+  Element,
+  div,
+  className,
+  text
+} from "MadUI"
+
+
+Etiquette :: String -> Element
+export Etiquette = (content) =>
+  <div className="definition__etiquette">
+    {content}
+  </div>

--- a/src/Views/Example.mad
+++ b/src/Views/Example.mad
@@ -1,5 +1,5 @@
+import type { Element } from "MadUI"
 import {
-  Element,
   className,
   empty,
   text,
@@ -8,7 +8,7 @@ import {
 import { always, ifElse } from "Function"
 import { isEmpty } from "String"
 
-Example :: { example :: String } -> Element
+Example :: { ...a, example :: String } -> Element
 export Example = pipe(
   .example,
   ifElse(

--- a/src/Views/Example.mad
+++ b/src/Views/Example.mad
@@ -1,0 +1,19 @@
+import {
+  Element,
+  className,
+  empty,
+  text,
+  p
+} from "MadUI"
+import { always, ifElse } from "Function"
+import { isEmpty } from "String"
+
+Example :: { example :: String } -> Element
+export Example = pipe(
+  .example,
+  ifElse(
+    isEmpty,
+    always(<empty />),
+    (example) => <p className="definition__example">{example}</p>
+  )
+)

--- a/src/Views/Expression.mad
+++ b/src/Views/Expression.mad
@@ -1,0 +1,28 @@
+import {
+  Element,
+  className,
+  text,
+  li
+} from "MadUI"
+
+import { Example } from "./Example"
+import { Since } from "./Since"
+import { Typing } from "./Typing"
+import { Etiquette } from "./Etiquette"
+import { Title } from "./Title"
+import { Description } from "./Description"
+
+import { Expression } from "../Parser/Documentation"
+
+Expression :: String -> Expression -> Element
+export Expression = (moduleName, definition) =>
+  <li className="definition">
+    {[
+        Etiquette("Function"),
+        Title(definition.name, moduleName),
+        Typing(definition),
+        Since(definition),
+        Description(definition),
+        Example(definition)
+    ]}
+  </li>

--- a/src/Views/Expression.mad
+++ b/src/Views/Expression.mad
@@ -5,14 +5,14 @@ import {
   li
 } from "MadUI"
 
-import { Example } from "./Example"
-import { Since } from "./Since"
-import { Typing } from "./Typing"
-import { Etiquette } from "./Etiquette"
-import { Title } from "./Title"
-import { Description } from "./Description"
+import { Etiquette } from "@/Views/Etiquette"
+import { Title } from "@/Views/Title"
+import { Since } from "@/Views/Since"
+import { Description } from "@/Views/Description"
+import { Example } from "@/Views/Example"
+import { Typing } from "@/Views/Typing"
 
-import type { Expression } from "../Parser/Documentation"
+import type { Expression } from "@/Parser/Documentation"
 
 Expression :: String -> Expression -> Element
 export Expression = (moduleName, definition) =>

--- a/src/Views/Expression.mad
+++ b/src/Views/Expression.mad
@@ -1,5 +1,5 @@
+import type { Element } from "MadUI"
 import {
-  Element,
   className,
   text,
   li
@@ -12,7 +12,7 @@ import { Etiquette } from "./Etiquette"
 import { Title } from "./Title"
 import { Description } from "./Description"
 
-import { Expression } from "../Parser/Documentation"
+import type { Expression } from "../Parser/Documentation"
 
 Expression :: String -> Expression -> Element
 export Expression = (moduleName, definition) =>

--- a/src/Views/Header.mad
+++ b/src/Views/Header.mad
@@ -13,7 +13,7 @@ import {
 import String from "String"
 import { always } from "Function"
 
-import type { State } from "../State"
+import type { State } from "@/State"
 
 handleInput :: Action State
 handleInput = (state, event) => where(event)

--- a/src/Views/Header.mad
+++ b/src/Views/Header.mad
@@ -1,0 +1,29 @@
+import {
+  Action,
+  Element,
+  onInput,
+  input,
+  className,
+  text,
+  placeholder,
+  InputEvent,
+  inputType,
+  h1,
+  header
+} from "MadUI"
+import { always } from "Function"
+
+import {
+  State
+} from "../State"
+
+handleInput :: Action State
+handleInput = (state, event) => where(event)
+  is InputEvent e: [of(always({ ...state, search: e.target.value }))]
+
+Header :: () -> Element
+export Header = (_) => 
+  <header className="header">
+    <h1 className="header__title">MadDoc</h1>
+    <input inputType="text" placeholder="What are you looking for?" className="search-field" onInput={handleInput} />
+  </header>

--- a/src/Views/Header.mad
+++ b/src/Views/Header.mad
@@ -1,6 +1,5 @@
+import type { Action, Element } from "MadUI"
 import {
-  Action,
-  Element,
   onInput,
   input,
   className,
@@ -11,15 +10,14 @@ import {
   h1,
   header
 } from "MadUI"
+import String from "String"
 import { always } from "Function"
 
-import {
-  State
-} from "../State"
+import type { State } from "../State"
 
 handleInput :: Action State
 handleInput = (state, event) => where(event)
-  is InputEvent e: [of(always({ ...state, search: e.target.value }))]
+  is InputEvent e: [of(always({ ...state, search: String.toLower(e.target.value) }))]
 
 Header :: () -> Element
 export Header = (_) => 

--- a/src/Views/Instance.mad
+++ b/src/Views/Instance.mad
@@ -1,0 +1,39 @@
+import {
+  Element,
+  div,
+  span,
+  className,
+  text,
+  li
+} from "MadUI"
+import IO from "IO"
+
+import { Etiquette } from "./Etiquette"
+import { Title } from "./Title"
+
+import { Instance } from "../Parser/Documentation"
+
+
+Instance :: String -> Instance -> Element
+export Instance = (moduleName, instanceDef) => {
+  constraints  = instanceDef.constraints
+  constraintElements =
+    if (constraints != "") {[
+        <span>{constraints}</span>,
+        <span className="highlight">{` => `}</span>
+    ]} else { [] }
+
+  return (
+    <li className="definition">
+      {[
+          Etiquette("Instance"),
+          Title(instanceDef.declaration, moduleName)
+      ]}
+      <div className="definition__interface">
+        <span className="highlight">instance </span>
+        <span>{constraintElements}</span>
+        <span>{instanceDef.declaration}</span>
+      </div>
+    </li>
+  )
+}

--- a/src/Views/Instance.mad
+++ b/src/Views/Instance.mad
@@ -7,13 +7,13 @@ import {
   li
 } from "MadUI"
 
-import { Etiquette } from "./Etiquette"
-import { Title } from "./Title"
-import { Since } from "./Since"
-import { Description } from "./Description"
-import { Example } from "./Example"
+import { Etiquette } from "@/Views/Etiquette"
+import { Title } from "@/Views/Title"
+import { Since } from "@/Views/Since"
+import { Description } from "@/Views/Description"
+import { Example } from "@/Views/Example"
 
-import type { Instance } from "../Parser/Documentation"
+import type { Instance } from "@/Parser/Documentation"
 
 
 Instance :: String -> Instance -> Element

--- a/src/Views/Instance.mad
+++ b/src/Views/Instance.mad
@@ -1,17 +1,19 @@
+import type { Element } from "MadUI"
 import {
-  Element,
   div,
   span,
   className,
   text,
   li
 } from "MadUI"
-import IO from "IO"
 
 import { Etiquette } from "./Etiquette"
 import { Title } from "./Title"
+import { Since } from "./Since"
+import { Description } from "./Description"
+import { Example } from "./Example"
 
-import { Instance } from "../Parser/Documentation"
+import type { Instance } from "../Parser/Documentation"
 
 
 Instance :: String -> Instance -> Element
@@ -22,6 +24,8 @@ export Instance = (moduleName, instanceDef) => {
         <span>{constraints}</span>,
         <span className="highlight">{` => `}</span>
     ]} else { [] }
+
+  p = Title(instanceDef.declaration, moduleName)
 
   return (
     <li className="definition">
@@ -34,6 +38,11 @@ export Instance = (moduleName, instanceDef) => {
         <span>{constraintElements}</span>
         <span>{instanceDef.declaration}</span>
       </div>
+      {[
+          Since(instanceDef),
+          Description(instanceDef),
+          Example(instanceDef)
+      ]}
     </li>
   )
 }

--- a/src/Views/Interface.mad
+++ b/src/Views/Interface.mad
@@ -6,15 +6,14 @@ import {
   text,
   li
 } from "MadUI"
-import IO from "IO"
 
-import { Etiquette } from "./Etiquette"
-import { Title } from "./Title"
-import { Since } from "./Since"
-import { Description } from "./Description"
-import { Example } from "./Example"
+import { Etiquette } from "@/Views/Etiquette"
+import { Title } from "@/Views/Title"
+import { Since } from "@/Views/Since"
+import { Description } from "@/Views/Description"
+import { Example } from "@/Views/Example"
 
-import type { Interface } from "../Parser/Documentation"
+import type { Interface } from "@/Parser/Documentation"
 
 
 Interface :: String -> Interface -> Element

--- a/src/Views/Interface.mad
+++ b/src/Views/Interface.mad
@@ -1,5 +1,5 @@
+import type { Element } from "MadUI"
 import {
-  Element,
   div,
   span,
   className,
@@ -10,8 +10,11 @@ import IO from "IO"
 
 import { Etiquette } from "./Etiquette"
 import { Title } from "./Title"
+import { Since } from "./Since"
+import { Description } from "./Description"
+import { Example } from "./Example"
 
-import { Interface } from "../Parser/Documentation"
+import type { Interface } from "../Parser/Documentation"
 
 
 Interface :: String -> Interface -> Element
@@ -38,6 +41,11 @@ export Interface = (moduleName, interfaceDef) => {
         <div>{map((method) => <div>  {method}</div>, methods)}</div>
         <span className="highlight">{`}`}</span>
       </div>
+      {[
+          Since(interfaceDef),
+          Description(interfaceDef),
+          Example(interfaceDef)
+      ]}
     </li>
   )
 }

--- a/src/Views/Interface.mad
+++ b/src/Views/Interface.mad
@@ -1,0 +1,43 @@
+import {
+  Element,
+  div,
+  span,
+  className,
+  text,
+  li
+} from "MadUI"
+import IO from "IO"
+
+import { Etiquette } from "./Etiquette"
+import { Title } from "./Title"
+
+import { Interface } from "../Parser/Documentation"
+
+
+Interface :: String -> Interface -> Element
+export Interface = (moduleName, interfaceDef) => {
+  methods      = interfaceDef.methods
+  constraints  = interfaceDef.constraints
+  constraintElements =
+    if (constraints != "") {[
+        <span>{constraints}</span>,
+        <span className="highlight">{` => `}</span>
+    ]} else { [] }
+
+  return (
+    <li className="definition">
+      {[
+          Etiquette("Interface"),
+          Title(interfaceDef.name, moduleName)
+      ]}
+      <div className="definition__interface">
+        <span className="highlight">interface </span>
+        <span>{constraintElements}</span>
+        <span>{interfaceDef.name} {interfaceDef.vars}</span>
+        <span className="highlight">{` {`}</span>
+        <div>{map((method) => <div>  {method}</div>, methods)}</div>
+        <span className="highlight">{`}`}</span>
+      </div>
+    </li>
+  )
+}

--- a/src/Views/SideMenu.mad
+++ b/src/Views/SideMenu.mad
@@ -1,0 +1,60 @@
+import L from "List"
+import {
+  Element,
+  div,
+  h2,
+  li,
+  link,
+  to,
+  className,
+  text,
+  ul
+} from "MadUI"
+import {} from "Compare"
+
+import {
+  Module,
+  Expression
+} from "../Parser/Documentation"
+
+ModuleLink :: Module -> Element
+ModuleLink = (module) =>
+  <li>
+    <link className="side-menu__link" to={`/${module.name}`}>
+      {module.name}
+    </link>
+  </li>
+
+FunctionLink :: <Expression, String> -> Element
+FunctionLink = where is <f, moduleName>:
+  <li>
+    <link className="side-menu__link" to={`/${moduleName}/${f.name}`}>
+      {f.name}
+    </link>
+  </li>
+
+FunctionLinks :: List Module -> List Element
+FunctionLinks = pipe(
+  chain((module) => pipe(
+    .expressions,
+    map((exp) => <exp, module.name>)
+  )(module)),
+  L.sortBy((a, b) => where(<a, b>)
+    is <<{ name: nameA }, _>, <{ name: nameB }, _>>:
+      compare(nameA, nameB)
+  ),
+  map(FunctionLink)
+)
+
+SideMenu :: List Module -> Element
+export SideMenu = (modules) =>
+  <div className="side-menu">
+    <h2>modules</h2>
+    <ul>
+      {map(ModuleLink, modules)}
+    </ul>
+    <h2>functions</h2>
+    <ul>
+      {FunctionLinks(modules)}
+    </ul>
+  </div>

--- a/src/Views/SideMenu.mad
+++ b/src/Views/SideMenu.mad
@@ -2,12 +2,13 @@ import L from "List"
 import {
   Element,
   div,
-  h2,
+  h3,
   li,
   link,
   to,
   className,
   text,
+  span,
   ul
 } from "MadUI"
 import {} from "Compare"
@@ -19,18 +20,20 @@ import {
 
 ModuleLink :: Module -> Element
 ModuleLink = (module) =>
-  <li>
+  <li className="side-menu__link-item">
     <link className="side-menu__link" to={`/${module.name}`}>
-      {module.name}
+      <span className="side-menu__link-name">{module.name}</span>
     </link>
   </li>
 
 FunctionLink :: <Expression, String> -> Element
 FunctionLink = where is <f, moduleName>:
-  <li>
+  <li className="side-menu__link-item">
     <link className="side-menu__link" to={`/${moduleName}/${f.name}`}>
-      {f.name}
+      <span className="side-menu__link-name">{f.name}</span>
+      <span className="side-menu__link-extra">{moduleName}</span>
     </link>
+
   </li>
 
 FunctionLinks :: List Module -> List Element
@@ -49,12 +52,14 @@ FunctionLinks = pipe(
 SideMenu :: List Module -> Element
 export SideMenu = (modules) =>
   <div className="side-menu">
-    <h2>modules</h2>
-    <ul>
-      {map(ModuleLink, modules)}
-    </ul>
-    <h2>functions</h2>
-    <ul>
-      {FunctionLinks(modules)}
-    </ul>
+    <div className="side-menu__scrollbar-container">
+      <h3 className="side-menu__title">MODULES</h3>
+      <ul className="side-menu__link-list">
+        {map(ModuleLink, modules)}
+      </ul>
+      <h3 className="side-menu__title">FUNCTIONS</h3>
+      <ul className="side-menu__link-list">
+        {FunctionLinks(modules)}
+      </ul>
+    </div>
   </div>

--- a/src/Views/SideMenu.mad
+++ b/src/Views/SideMenu.mad
@@ -1,4 +1,5 @@
-import L from "List"
+import List from "List"
+import Tuple from "Tuple"
 import {
   Element,
   div,
@@ -26,28 +27,68 @@ ModuleLink = (module) =>
     </link>
   </li>
 
-FunctionLink :: <Expression, String> -> Element
-FunctionLink = where is <f, moduleName>:
+MenuLink :: <String, String> -> Element
+MenuLink = where is <name, moduleName>:
   <li className="side-menu__link-item">
-    <link className="side-menu__link" to={`/${moduleName}/${f.name}`}>
-      <span className="side-menu__link-name">{f.name}</span>
+    <link className="side-menu__link" to={`/${moduleName}/${name}`}>
+      <span className="side-menu__link-name">{name}</span>
       <span className="side-menu__link-extra">{moduleName}</span>
     </link>
-
   </li>
 
 FunctionLinks :: List Module -> List Element
 FunctionLinks = pipe(
   chain((module) => pipe(
     .expressions,
-    map((exp) => <exp, module.name>)
+    map((exp) => <exp.name, module.name>)
   )(module)),
-  L.sortBy((a, b) => where(<a, b>)
-    is <<{ name: nameA }, _>, <{ name: nameB }, _>>:
-      compare(nameA, nameB)
-  ),
-  map(FunctionLink)
+  itemsToLinks
 )
+
+TypeLinks :: List Module -> List Element
+TypeLinks = pipe(
+  chain((module) => pipe(
+    .typeDeclarations,
+    map((typeDecl) => <typeDecl.name, module.name>)
+  )(module)),
+  itemsToLinks
+)
+
+AliasLinks :: List Module -> List Element
+AliasLinks = pipe(
+  chain((module) => pipe(
+    .aliases,
+    map((a) => <a.name, module.name>)
+  )(module)),
+  itemsToLinks
+)
+
+InterfaceLinks :: List Module -> List Element
+InterfaceLinks = pipe(
+  chain((module) => pipe(
+    .interfaces,
+    map((a) => <a.name, module.name>)
+  )(module)),
+  itemsToLinks
+)
+
+InstanceLinks :: List Module -> List Element
+InstanceLinks = pipe(
+  chain((module) => pipe(
+    .instances,
+    map((a) => <a.declaration, module.name>)
+  )(module)),
+  itemsToLinks
+)
+
+itemsToLinks :: List <String, String> -> List Element
+itemsToLinks = pipe(
+  List.sortBy((a, b) => compare(Tuple.fst(a), Tuple.fst(b))),
+  map(MenuLink)
+)
+
+sortModules :: List Module -> List Module
+sortModules = List.sortBy((a, b) => compare(a.name, b.name))
 
 SideMenu :: List Module -> Element
 export SideMenu = (modules) =>
@@ -55,11 +96,27 @@ export SideMenu = (modules) =>
     <div className="side-menu__scrollbar-container">
       <h3 className="side-menu__title">MODULES</h3>
       <ul className="side-menu__link-list">
-        {map(ModuleLink, modules)}
+        {map(ModuleLink, sortModules(modules))}
       </ul>
       <h3 className="side-menu__title">FUNCTIONS</h3>
       <ul className="side-menu__link-list">
         {FunctionLinks(modules)}
+      </ul>
+      <h3 className="side-menu__title">TYPES</h3>
+      <ul className="side-menu__link-list">
+        {TypeLinks(modules)}
+      </ul>
+      <h3 className="side-menu__title">ALIASES</h3>
+      <ul className="side-menu__link-list">
+        {AliasLinks(modules)}
+      </ul>
+      <h3 className="side-menu__title">INTERFACES</h3>
+      <ul className="side-menu__link-list">
+        {InterfaceLinks(modules)}
+      </ul>
+      <h3 className="side-menu__title">INSTANCES</h3>
+      <ul className="side-menu__link-list">
+        {InstanceLinks(modules)}
       </ul>
     </div>
   </div>

--- a/src/Views/SideMenu.mad
+++ b/src/Views/SideMenu.mad
@@ -1,9 +1,12 @@
 import List from "List"
 import Tuple from "Tuple"
+import String from "String"
+import { all } from "Function"
+import type { Element } from "MadUI"
 import {
-  Element,
   div,
   h3,
+  p,
   li,
   link,
   to,
@@ -14,10 +17,7 @@ import {
 } from "MadUI"
 import {} from "Compare"
 
-import {
-  Module,
-  Expression
-} from "../Parser/Documentation"
+import type { Module } from "../Parser/Documentation"
 
 ModuleLink :: Module -> Element
 ModuleLink = (module) =>
@@ -36,47 +36,16 @@ MenuLink = where is <name, moduleName>:
     </link>
   </li>
 
-FunctionLinks :: List Module -> List Element
-FunctionLinks = pipe(
+LinksForType :: String
+  -> ({ ...a, name :: String } -> List b)
+  -> (b -> String)
+  -> List { ...a, name :: String }
+  -> List Element
+LinksForType = (search, getItems, getName) => pipe(
   chain((module) => pipe(
-    .expressions,
-    map((exp) => <exp.name, module.name>)
-  )(module)),
-  itemsToLinks
-)
-
-TypeLinks :: List Module -> List Element
-TypeLinks = pipe(
-  chain((module) => pipe(
-    .typeDeclarations,
-    map((typeDecl) => <typeDecl.name, module.name>)
-  )(module)),
-  itemsToLinks
-)
-
-AliasLinks :: List Module -> List Element
-AliasLinks = pipe(
-  chain((module) => pipe(
-    .aliases,
-    map((a) => <a.name, module.name>)
-  )(module)),
-  itemsToLinks
-)
-
-InterfaceLinks :: List Module -> List Element
-InterfaceLinks = pipe(
-  chain((module) => pipe(
-    .interfaces,
-    map((a) => <a.name, module.name>)
-  )(module)),
-  itemsToLinks
-)
-
-InstanceLinks :: List Module -> List Element
-InstanceLinks = pipe(
-  chain((module) => pipe(
-    .instances,
-    map((a) => <a.declaration, module.name>)
+    getItems,
+    List.filter(pipe(getName, String.toLower, String.match(search))),
+    map((a) => <getName(a), module.name>)
   )(module)),
   itemsToLinks
 )
@@ -87,36 +56,61 @@ itemsToLinks = pipe(
   map(MenuLink)
 )
 
-sortModules :: List Module -> List Module
-sortModules = List.sortBy((a, b) => compare(a.name, b.name))
+sortAndFilterModules :: String -> List Module -> List Module
+sortAndFilterModules = (search) => pipe(
+  List.filter(pipe(.name, String.toLower, String.match(search))),
+  List.sortBy((a, b) => compare(a.name, b.name))
+)
 
-SideMenu :: List Module -> Element
-export SideMenu = (modules) =>
-  <div className="side-menu">
-    <div className="side-menu__scrollbar-container">
-      <h3 className="side-menu__title">MODULES</h3>
+MenuSection :: String -> List Element -> List Element
+MenuSection = (title, items) => List.isEmpty(items)
+  ? []
+  : [
+      <h3 className="side-menu__title">{title}</h3>,
       <ul className="side-menu__link-list">
-        {map(ModuleLink, sortModules(modules))}
+        {items}
       </ul>
-      <h3 className="side-menu__title">FUNCTIONS</h3>
-      <ul className="side-menu__link-list">
-        {FunctionLinks(modules)}
-      </ul>
-      <h3 className="side-menu__title">TYPES</h3>
-      <ul className="side-menu__link-list">
-        {TypeLinks(modules)}
-      </ul>
-      <h3 className="side-menu__title">ALIASES</h3>
-      <ul className="side-menu__link-list">
-        {AliasLinks(modules)}
-      </ul>
-      <h3 className="side-menu__title">INTERFACES</h3>
-      <ul className="side-menu__link-list">
-        {InterfaceLinks(modules)}
-      </ul>
-      <h3 className="side-menu__title">INSTANCES</h3>
-      <ul className="side-menu__link-list">
-        {InstanceLinks(modules)}
-      </ul>
-    </div>
-  </div>
+    ]
+
+SideMenu :: String -> List Module -> Element
+export SideMenu = (search, modules) => {
+  moduleLinks = map(ModuleLink, sortAndFilterModules(search, modules))
+  functionLinks = LinksForType(search, .expressions, .name, modules)
+  typeLinks = LinksForType(search, .typeDeclarations, .name, modules)
+  aliasLinks = LinksForType(search, .aliases, .name, modules)
+  interfaceLinks = LinksForType(search, .interfaces, .name, modules)
+  instanceLinks = LinksForType(search, .instances, .declaration, modules)
+
+  notFound = all(
+    List.isEmpty,
+    [
+      moduleLinks,
+      functionLinks,
+      typeLinks,
+      aliasLinks,
+      interfaceLinks,
+      instanceLinks
+    ]
+  )
+
+  return notFound
+    ? (
+        <div className="side-menu">
+          <p className="side-menu__no-result">
+            No result was found for '<span className="side-menu__no-result-search">{search}</span>'
+          </p>
+        </div>
+      )
+    : (
+        <div className="side-menu">
+          <div className="side-menu__scrollbar-container">
+            {MenuSection("MODULES", moduleLinks)}
+            {MenuSection("FUNCTIONS", functionLinks)}
+            {MenuSection("TYPES", typeLinks)}
+            {MenuSection("ALIASES", aliasLinks)}
+            {MenuSection("INTERFACES", interfaceLinks)}
+            {MenuSection("INSTANCES", instanceLinks)}
+          </div>
+        </div>
+      )
+}

--- a/src/Views/SideMenu.mad
+++ b/src/Views/SideMenu.mad
@@ -17,7 +17,7 @@ import {
 } from "MadUI"
 import {} from "Compare"
 
-import type { Module } from "../Parser/Documentation"
+import type { Module } from "@/Parser/Documentation"
 
 ModuleLink :: Module -> Element
 ModuleLink = (module) =>
@@ -97,7 +97,7 @@ export SideMenu = (search, modules) => {
     ? (
         <div className="side-menu">
           <p className="side-menu__no-result">
-            No result was found for '<span className="side-menu__no-result-search">{search}</span>'
+            No result was found for <span className="side-menu__no-result-search">{search}</span>
           </p>
         </div>
       )

--- a/src/Views/Since.mad
+++ b/src/Views/Since.mad
@@ -1,0 +1,19 @@
+import {
+  Element,
+  className,
+  empty,
+  text,
+  p
+} from "MadUI"
+import { always, ifElse } from "Function"
+import { isEmpty } from "String"
+
+Since :: { since :: String } -> Element
+export Since = pipe(
+  .since,
+  ifElse(
+    isEmpty,
+    always(<empty />),
+    (since) => <p className="definition__since">since v{since}</p>
+  )
+)

--- a/src/Views/Since.mad
+++ b/src/Views/Since.mad
@@ -1,5 +1,5 @@
+import type { Element } from "MadUI"
 import {
-  Element,
   className,
   empty,
   text,
@@ -8,7 +8,7 @@ import {
 import { always, ifElse } from "Function"
 import { isEmpty } from "String"
 
-Since :: { since :: String } -> Element
+Since :: { ...a, since :: String } -> Element
 export Since = pipe(
   .since,
   ifElse(

--- a/src/Views/Title.mad
+++ b/src/Views/Title.mad
@@ -1,5 +1,5 @@
+import type { Element } from "MadUI"
 import {
-  Element,
   h2,
   span,
   className,

--- a/src/Views/Title.mad
+++ b/src/Views/Title.mad
@@ -1,0 +1,15 @@
+import {
+  Element,
+  h2,
+  span,
+  className,
+  text
+} from "MadUI"
+
+
+Title :: String -> String -> Element
+export Title = (title, moduleName) =>
+  <h2 className="definition__title">
+    <span>{title}</span>
+    <span className="definition__module">{moduleName}</span>
+  </h2>

--- a/src/Views/Type.mad
+++ b/src/Views/Type.mad
@@ -1,20 +1,21 @@
 import { len, first } from "List"
 import { fromMaybe } from "Maybe"
+import type { Element } from "MadUI"
 import {
-  Element,
-  View,
   div,
   span,
   className,
   text,
   li
 } from "MadUI"
-import IO from "IO"
 
 import { Etiquette } from "./Etiquette"
 import { Title } from "./Title"
+import { Since } from "./Since"
+import { Description } from "./Description"
+import { Example } from "./Example"
 
-import { Type } from "../Parser/Documentation"
+import type { Type } from "../Parser/Documentation"
 
 
 Type :: String -> Type -> Element
@@ -26,7 +27,7 @@ export Type = (moduleName, typeDefinition) => {
     ? ConstructorsView("=", constructors)
     : [
       <span className="definition__constructor">
-        <span className="highlight">= </span>
+        <span className="highlight"> = </span>
         <span>{fromMaybe("???", first(constructors))}</span>
       </span>
     ]
@@ -42,6 +43,11 @@ export Type = (moduleName, typeDefinition) => {
         <span> {typeDefinition.name} {typeDefinition.params}</span>
         <span className="definition__constructors">{renderedConstructors}</span>
       </div>
+      {[
+          Since(typeDefinition),
+          Description(typeDefinition),
+          Example(typeDefinition)
+      ]}
     </li>
   )
 }
@@ -52,7 +58,7 @@ ConstructorsView = (separator, items) => where(items)
   is [ctor]         : [ConstructorView(separator, ctor)]
   is []             : []
 
-ConstructorView :: String -> View String
+ConstructorView :: String -> String -> Element
 ConstructorView = (separator, constructor) =>
   <div className="definition__constructor">
     <span className="highlight">  {separator}</span>

--- a/src/Views/Type.mad
+++ b/src/Views/Type.mad
@@ -15,7 +15,7 @@ import { Since } from "./Since"
 import { Description } from "./Description"
 import { Example } from "./Example"
 
-import type { Type } from "../Parser/Documentation"
+import type { Type } from "@/Parser/Documentation"
 
 
 Type :: String -> Type -> Element

--- a/src/Views/Type.mad
+++ b/src/Views/Type.mad
@@ -1,0 +1,60 @@
+import { len, first } from "List"
+import { fromMaybe } from "Maybe"
+import {
+  Element,
+  View,
+  div,
+  span,
+  className,
+  text,
+  li
+} from "MadUI"
+import IO from "IO"
+
+import { Etiquette } from "./Etiquette"
+import { Title } from "./Title"
+
+import { Type } from "../Parser/Documentation"
+
+
+Type :: String -> Type -> Element
+export Type = (moduleName, typeDefinition) => {
+  constructors   = typeDefinition.constructors
+  manyCtors      = len(constructors) > 1
+
+  renderedConstructors = manyCtors
+    ? ConstructorsView("=", constructors)
+    : [
+      <span className="definition__constructor">
+        <span className="highlight">= </span>
+        <span>{fromMaybe("???", first(constructors))}</span>
+      </span>
+    ]
+
+  return (
+    <li className="definition">
+      {[
+          Etiquette("Type"),
+          Title(typeDefinition.name, moduleName)
+      ]}
+      <div className="definition__adt">
+        <span className="highlight">type</span>
+        <span> {typeDefinition.name} {typeDefinition.params}</span>
+        <span className="definition__constructors">{renderedConstructors}</span>
+      </div>
+    </li>
+  )
+}
+
+ConstructorsView :: String -> (List String) -> List Element
+ConstructorsView = (separator, items) => where(items)
+  is [ctor, ...more]: [ConstructorView(separator, ctor), ...ConstructorsView("|", more)]
+  is [ctor]         : [ConstructorView(separator, ctor)]
+  is []             : []
+
+ConstructorView :: String -> View String
+ConstructorView = (separator, constructor) =>
+  <div className="definition__constructor">
+    <span className="highlight">  {separator}</span>
+    <span> {constructor}</span>
+  </div>

--- a/src/Views/Typing.mad
+++ b/src/Views/Typing.mad
@@ -1,0 +1,16 @@
+import {
+  Element,
+  className,
+  span,
+  text,
+  p
+} from "MadUI"
+
+Typing :: { typing :: String } -> Element
+export Typing = pipe(
+  .typing,
+  (typing) =>
+    <p>
+      <span className="definition__type">{typing}</span>
+    </p>
+)

--- a/src/Views/Typing.mad
+++ b/src/Views/Typing.mad
@@ -1,5 +1,5 @@
+import type { Element } from "MadUI"
 import {
-  Element,
   className,
   span,
   text,

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -27,30 +27,83 @@ body {
   min-height: 100vh;
 }
 
+
+// ----------------------------------------------
+// Side Menu
+// ----------------------------------------------
+
 .side-menu {
-  min-width: 200px;
-  padding: 20px 20px 0 20px;
-  overflow: scroll;
   background-color: white;
-  height: calc(100vh - 100px);
+  height: calc(100vh - 80px);
   position: sticky;
   top: 80px;
   border-right: 1px solid #ccc;
 }
 
-.side-menu__link {
-  cursor: pointer;
-  
+.side-menu__scrollbar-container {
+  height: 100%;
+  overflow: scroll;
 }
+
+.side-menu__title {
+  padding: 0 15px 0 15px;
+  font-size: 24px;
+  margin-bottom: 5px;
+}
+
+.side-menu__link-list {
+  margin: 0;
+  padding-bottom: 20px;
+}
+
+.side-menu__link {
+  box-sizing: border-box;
+  cursor: pointer;
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  padding: 5px 15px;
+
+  &:hover {
+    background: $background-color;
+  }
+}
+
+.side-menu__link-name {
+  flex-grow: 1;
+  margin-right: 20px;
+  font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+}
+
+.side-menu__link-extra {
+  background-color: $primary-color-light;
+  color: $primary-color;
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+
+
+// ----------------------------------------------
+// Main Content
+// ----------------------------------------------
 
 .documentation__content {
   min-width: 230px;
   flex-grow: 1;
   padding-left: 30px;
-  padding-top: 150px;
+  padding-top: 100px;
 }
 
-.documentation__header {
+.content__items {
+  margin-top: 50px;
+}
+
+
+// ----------------------------------------------
+// Header
+// ----------------------------------------------
+
+.header {
   height: 60px;
   padding: 10px 10px 10px 30px;
   position: fixed;
@@ -61,20 +114,34 @@ body {
   box-shadow: 0px 0px 10px 2px rgba(0,0,0,0.36);
 }
 
-.search-field {
-  margin-top: 3px;
-    min-width: 350px;
-    padding: 10px;
-    font-size: 18px;
-    background: transparent;
-    color: white;
-    border: none;
-    border-bottom: 1px solid white;
-
-    &::placeholder {
-      color: rgba(255, 255, 255, 0.5);
-    }
+.header__title {
+  display: inline-block;
+  margin: 15px 0;
 }
+
+.search-field {
+  background: white;
+  border: none;
+  border-radius: 5px;
+  padding: 10px;
+  min-width: 350px;
+  position: relative;
+  display: -webkit-inline-box;
+  top: -7px;
+  margin-left: 50px;
+
+  box-shadow: inset 0px 0px 5px -1px rgb(0 0 0 / 80%);
+
+  &::placeholder {
+    color: #aaa;
+    font-style: italic;
+  }
+}
+
+
+// ----------------------------------------------
+// Definition
+// ----------------------------------------------
 
 .definition {
   font-size: 16px;
@@ -169,4 +236,44 @@ body {
 .definition__adt, .definition__interface {
   white-space: pre;
   font-family: Menlo,Monaco,Consolas,"Courier New",monospace;
+}
+
+
+// ----------------------------------------------
+// Breadcrumbs
+// ----------------------------------------------
+
+.breadcrumbs {
+  margin: 0 0 40px 0;
+}
+
+.breadcrumbs__item {
+  display: inline-block;
+  cursor: pointer;
+}
+
+.breadcrumbs__separator {
+  margin: 0 10px;
+}
+
+// ----------------------------------------------
+// Module
+// ----------------------------------------------
+
+.module {
+  margin-bottom: 80px;
+}
+
+.module__title {
+  margin: 0 0 20px 0;
+  font-size: 40px;
+
+  > a {
+    cursor: pointer;
+  }
+}
+
+.module__description {
+  margin: 0 0 30px 0;
+  font-size: 16px;
 }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -21,8 +21,31 @@ body {
   --webkit-font-smoothing: antialiased;
 }
 
+.documentation {
+  display: flex;
+  flex-direction: row;
+  min-height: 100vh;
+}
+
+.side-menu {
+  min-width: 200px;
+  padding: 20px 20px 0 20px;
+  overflow: scroll;
+  background-color: white;
+  height: calc(100vh - 100px);
+  position: sticky;
+  top: 80px;
+  border-right: 1px solid #ccc;
+}
+
+.side-menu__link {
+  cursor: pointer;
+  
+}
+
 .documentation__content {
   min-width: 230px;
+  flex-grow: 1;
   padding-left: 30px;
   padding-top: 150px;
 }
@@ -129,7 +152,8 @@ body {
   margin: 0 -15px -15px -15px;
   padding: 15px;
   font-weight: 500;
-  white-space: pre;
+  white-space: pre-wrap;
+  word-wrap: break-word;
   font-family: Menlo,Monaco,Consolas,"Courier New",monospace;
 }
 

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -27,6 +27,11 @@ body {
   min-height: 100vh;
 }
 
+a {
+  color: inherit;
+  text-decoration: none;
+} 
+
 
 // ----------------------------------------------
 // Side Menu
@@ -73,6 +78,7 @@ body {
   flex-grow: 1;
   margin-right: 20px;
   font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+  white-space: nowrap;
 }
 
 .side-menu__link-extra {
@@ -234,7 +240,7 @@ body {
 }
 
 .definition__adt, .definition__interface {
-  white-space: pre;
+  white-space: pre-wrap;
   font-family: Menlo,Monaco,Consolas,"Courier New",monospace;
 }
 

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -38,11 +38,22 @@ a {
 // ----------------------------------------------
 
 .side-menu {
+  min-width: 300px;
   background-color: white;
   height: calc(100vh - 80px);
   position: sticky;
   top: 80px;
   border-right: 1px solid #ccc;
+  flex-shrink: 0;
+}
+
+.side-menu__no-result {
+  padding: 20px;
+  max-width: 300px;
+}
+
+.side-menu__no-result-search {
+  font-weight: 800;
 }
 
 .side-menu__scrollbar-container {
@@ -96,8 +107,7 @@ a {
 .documentation__content {
   min-width: 230px;
   flex-grow: 1;
-  padding-left: 30px;
-  padding-top: 100px;
+  padding: 100px 30px 0 30px;
 }
 
 .content__items {
@@ -151,7 +161,7 @@ a {
 
 .definition {
   font-size: 16px;
-  margin: 0 30px 30px 0;
+  margin: 0 0 30px 0;
   border: 1px solid #fff;
   -webkit-box-shadow: 0 0 0 1px #ccc;
   box-shadow: 0 0 0 1px #ccc;
@@ -246,6 +256,48 @@ a {
 
 
 // ----------------------------------------------
+// Markdown
+// ----------------------------------------------
+.markdown {
+  line-height: 1.5;
+
+  p {
+    margin-top: 0;
+    margin-bottom: 10px;
+  }
+
+  ul {
+    padding-left: 20px;
+
+    li::before {
+      content: " ";
+      font-size: 16px;
+      display: inline-block;
+      width: 6px;
+      height: 6px;
+      background: black;
+      border-radius: 8px;
+      margin-right: 10px;
+      margin-bottom: 2px;
+    }
+  }
+}
+
+.markdown__inline-code {
+  background-color: $background-color;
+  border-radius: 4px;
+  font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+  padding: 2px 4px;
+}
+
+.markdown__link {
+  color: $primary-color;
+  cursor: pointer;
+}
+
+
+
+// ----------------------------------------------
 // Breadcrumbs
 // ----------------------------------------------
 
@@ -280,6 +332,11 @@ a {
 }
 
 .module__description {
-  margin: 0 0 30px 0;
+  margin: 0 0 80px 0;
   font-size: 16px;
+  background-color: white;
+  box-shadow: 0 0 0 1px #ccc;
+  border: 1px solid #fff;
+  border-radius: 2px;
+  padding: 15px;
 }


### PR DESCRIPTION
- [x] split up views
- [x] add breadcrumbs
- [x] add navigation and module view
- [x] complete all types of documented things ( types, interfaces, ... ) and render all their fields ( example, since, ... )
- [ ] introduce strata
- [ ] have a back link ( I’m thinking something like ... link under modules on the left menu, or directly something always available in the header )
- [ ] add a doc section in the madlib.json so that we can add meta data there and an entrypoint so that you can directly use madlib doc in a package and it can generate version, package name etc automatically. Alternatively I’m thinking of providing a way to just give these via cli as well which would be helpful for say prelude API docs ( as prelude is not exactly a true package ), but also I’m thinking that this way we could make the tool more flexible by having more control say for mono repo use cases or else
- [ ] introduce markdown renderer so that we can get the interlinking working ( also that needs an extension of the current markdown renderer to allow to give custom views for markdown elements )